### PR TITLE
feat: Add toolbar feedback buttons with Sentry feedback form integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,12 @@ build-ios-share-extension:
 # TESTING
 # ============================================================================
 
+# Optional: ONLY_TESTING=Target/ClassName or Target/ClassName/testMethodName to run specific tests
+# Examples:
+#   make test-ios-app ONLY_TESTING=AppTests/SomeTestClass
+#   make test-ui ONLY_TESTING=UITests/UITests/testFeedbackButtonExistsOnListsView
+ONLY_TESTING ?=
+
 ## Run all iOS UI test suites
 #
 # Runs all UI tests for all primary iOS targets.
@@ -115,25 +121,40 @@ test-ios: test-ios-app
 #
 # Runs unit tests for the App scheme on the latest iOS Simulator (iPhone 17 Pro).
 # Writes logs to raw-test-ios-app.log and formats output with xcbeautify.
+#
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Examples:
+#   make test-ios-app
+#   make test-ios-app ONLY_TESTING=AppTests/SomeTestClass
 .PHONY: test-ios-app
 test-ios-app:
-	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme App -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' test | tee raw-test-ios-app.log | xcbeautify --preserve-unbeautified
+	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme App -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' $(if $(ONLY_TESTING),-only-testing:$(ONLY_TESTING)) test | tee raw-test-ios-app.log | xcbeautify --preserve-unbeautified
 
 ## Run unit tests for FlinkyCore on latest iOS Simulator
 #
 # Runs unit tests for the FlinkyCore scheme on the latest iOS Simulator (iPhone 17 Pro).
 # Core module tests to validate shared logic and utilities.
+#
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Examples:
+#   make test-ios-core
+#   make test-ios-core ONLY_TESTING=FlinkyCoreTests/SomeTestClass
 .PHONY: test-ios-core
-test-ios-core: 
-	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme FlinkyCore -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' test | tee raw-test-ios-core.log | xcbeautify --preserve-unbeautified
+test-ios-core:
+	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme FlinkyCore -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' $(if $(ONLY_TESTING),-only-testing:$(ONLY_TESTING)) test | tee raw-test-ios-core.log | xcbeautify --preserve-unbeautified
 
 ## Run tests for ShareExtension target on latest iOS Simulator
 #
 # Runs unit tests for the ShareExtension scheme on the latest iOS Simulator (iPhone 17 Pro).
 # Tests specific to the share extension behavior.
+#
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Examples:
+#   make test-ios-share-extension
+#   make test-ios-share-extension ONLY_TESTING=ShareExtensionTests/SomeTestClass
 .PHONY: test-ios-share-extension
 test-ios-share-extension:
-	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme ShareExtensionTests -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' test | tee raw-test-ios-share-extension.log | xcbeautify --preserve-unbeautified
+	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme ShareExtensionTests -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' $(if $(ONLY_TESTING),-only-testing:$(ONLY_TESTING)) test | tee raw-test-ios-share-extension.log | xcbeautify --preserve-unbeautified
 
 ## Run all UI test suites
 #
@@ -156,25 +177,34 @@ test-ui-ios: test-ui-ios-app
 ## Run primary UI tests (UITests scheme) on latest iOS Simulator
 #
 # Runs UI tests for the App scheme on the latest iOS Simulator (iPhone 17 Pro).
+#
+# Optional: ONLY_TESTING=Target/ClassName/testMethodName to run specific test(s)
+# Examples:
+#   make test-ui-ios-app
+#   make test-ui-ios-app ONLY_TESTING=UITests/UITests/testFeedbackButtonExistsOnListsView
 .PHONY: test-ui-ios-app
 test-ui-ios-app:
-	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme UITests -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' test | tee raw-test-ui-ios-app.log | xcbeautify --preserve-unbeautified
+	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme UITests -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' $(if $(ONLY_TESTING),-only-testing:$(ONLY_TESTING)) test | tee raw-test-ui-ios-app.log | xcbeautify --preserve-unbeautified
 
 ## Run screenshot UI tests (ScreenshotUITests scheme)
 #
 # Runs UI tests for the ScreenshotUITests scheme on the latest iOS Simulator (iPhone 17 Pro).
 # Generates localized marketing screenshots via UI automation.
+#
+# Optional: ONLY_TESTING=Target/ClassName/testMethodName to run specific test(s)
 .PHONY: test-ui-ios-screenshot
 test-ui-ios-screenshot:
-	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme ScreenshotUITests -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' test | tee raw-test-ui-screenshot-ios.log | xcbeautify --preserve-unbeautified
+	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme ScreenshotUITests -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' $(if $(ONLY_TESTING),-only-testing:$(ONLY_TESTING)) test | tee raw-test-ui-screenshot-ios.log | xcbeautify --preserve-unbeautified
 
 ## Run UI tests for ShareExtension
 #
 # Runs UI tests for the ShareExtensionUITests scheme on the latest iOS Simulator (iPhone 17 Pro).
 # UI tests targeting the share extension interface.
+#
+# Optional: ONLY_TESTING=Target/ClassName/testMethodName to run specific test(s)
 .PHONY: test-ui-ios-share-extension
 test-ui-ios-share-extension:
-	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme ShareExtensionUITests -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' test | tee raw-test-ui-share-extension-ios.log | xcbeautify --preserve-unbeautified
+	set -o pipefail && NSUnbufferedIO=YES xcrun xcodebuild -project Flinky.xcodeproj -scheme ShareExtensionUITests -destination 'platform=iOS Simulator,OS=$(SIMULATOR_OS),name=$(DEVICE_NAME)' $(if $(ONLY_TESTING),-only-testing:$(ONLY_TESTING)) test | tee raw-test-ui-share-extension-ios.log | xcbeautify --preserve-unbeautified
 
 # ============================================================================
 # FORMATTING

--- a/Targets/App/Sources/Environment/Environment+Feedback.swift
+++ b/Targets/App/Sources/Environment/Environment+Feedback.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct FeedbackAction {
+    private let handler: () -> Void
+
+    init(handler: @escaping () -> Void = {}) {
+        self.handler = handler
+    }
+
+    func show() {
+        handler()
+    }
+}
+
+extension EnvironmentValues {
+    var feedback: FeedbackAction {
+        get { self[FeedbackKey.self] }
+        set { self[FeedbackKey.self] = newValue }
+    }
+
+    private struct FeedbackKey: EnvironmentKey {
+        static let defaultValue = FeedbackAction()
+    }
+}

--- a/Targets/App/Sources/Generated/L10n.swift
+++ b/Targets/App/Sources/Generated/L10n.swift
@@ -39,6 +39,16 @@ internal enum L10n {
         /// New List
         internal static let title = L10n.tr("create-list.title", fallback: "New List")
     }
+    internal enum Feedback {
+        internal enum Toast {
+            internal enum Submit {
+                /// Failed to submit feedback
+                internal static let error = L10n.tr("feedback.toast.submit.error", fallback: "Failed to submit feedback")
+                /// Feedback submitted successfully
+                internal static let success = L10n.tr("feedback.toast.submit.success", fallback: "Feedback submitted successfully")
+            }
+        }
+    }
     internal enum LinkDetail {
         internal enum EditLink {
             /// Edit
@@ -215,6 +225,16 @@ internal enum L10n {
                 internal enum Accessibility {
                     /// Edit
                     internal static let label = L10n.tr("shared.button.edit.accessibility.label", fallback: "Edit")
+                }
+            }
+            internal enum Feedback {
+                /// Send Feedback
+                internal static let label = L10n.tr("shared.button.feedback.label", fallback: "Send Feedback")
+                internal enum Accessibility {
+                    /// Send feedback to help improve the app
+                    internal static let hint = L10n.tr("shared.button.feedback.accessibility.hint", fallback: "Send feedback to help improve the app")
+                    /// Send Feedback
+                    internal static let label = L10n.tr("shared.button.feedback.accessibility.label", fallback: "Send Feedback")
                 }
             }
             internal enum NewLink {

--- a/Targets/App/Sources/Main/FlinkyApp.swift
+++ b/Targets/App/Sources/Main/FlinkyApp.swift
@@ -7,19 +7,20 @@ import os.log
 
 @main
 struct FlinkyApp: App {
-    static let logger = Logger.forType(Self.self)
+    private static let logger = Logger.forType(Self.self)
 
-    @StateObject private var toastManager = ToastManager()
+    private static let sharedToastManager = ToastManager()
+    @StateObject private var toastManager = FlinkyApp.sharedToastManager
     private let sharedModelContainer: ModelContainer
 
     init() {
+        let isTestingEnabled = ProcessInfo.processInfo.isTestingEnabled
         SentrySDK.start { options in
-            Self.configureSentry(options: options)
+            Self.configureSentry(options: options, toastManager: Self.sharedToastManager, isTestingEnabled: isTestingEnabled)
         }
 
         // Start app health observation for system-level metrics
         // (thermal state, network reachability, app state transitions)
-        // Reference: https://github.com/getsentry/sentry-cocoa/issues/7000
         AppHealthObserver.shared.startObserving()
 
         // Subscribe to MetricKit payloads and report all values as Sentry metrics
@@ -27,7 +28,7 @@ struct FlinkyApp: App {
 
         do {
             sharedModelContainer = try SharedModelContainerFactory.make(
-                isStoredInMemoryOnly: ProcessInfo.processInfo.isTestingEnabled
+                isStoredInMemoryOnly: isTestingEnabled
             )
         } catch {
             fatalError("Failed to create shared ModelContainer: \(error)")
@@ -42,15 +43,19 @@ struct FlinkyApp: App {
     /// This method is defined as `private static` to because it is called from a non-mutating context.
     ///
     /// - Parameter options: Options structure to configure Sentry.
-    private static func configureSentry(options: Options) {  // swiftlint:disable:this function_body_length
-        // Disable Sentry for tests because it produces a lot of noise.
-        if ProcessInfo.processInfo.isTestingEnabled {
-            Self.logger.warning("Sentry is disabled in test environment")
-            return
-        }
-
+    /// - Parameter toastManager: The toast manager for feedback callbacks.
+    /// - Parameter isTestingEnabled: A boolean indicating if testing is enabled.
+    private static func configureSentry( // swiftlint:disable:this function_body_length
+        options: Options,
+        toastManager: ToastManager,
+        isTestingEnabled: Bool
+    ) {
+        options.enabled = !isTestingEnabled
         options.debug = pickEnvValue(production: false, develop: true)
         options.dsn = "https://f371822cfa840de0c6a27a788a5fa48e@o188824.ingest.us.sentry.io/4509640637349888"
+        if isTestingEnabled {
+            options.dsn = "https://00000000000000000000000000000000@o0.ingest.sentry.io/0"
+        }
 
         let bundleId = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
@@ -120,15 +125,6 @@ struct FlinkyApp: App {
         // Configure User Feedback
         options.configureUserFeedback = { feedbackOptions in
             feedbackOptions.animations = true
-            feedbackOptions.configureWidget = { widgetOptions in
-                widgetOptions.autoInject = false  // Disable automatic injection of the widget, because it's not supported in SwiftUI.
-                widgetOptions.labelText = "Send Feedback"
-                widgetOptions.showIcon = true
-                widgetOptions.widgetAccessibilityLabel = "Feedback Widget"
-                widgetOptions.windowLevel = UIWindow.Level.normal + 1
-                widgetOptions.location = [.bottom, .trailing]
-                widgetOptions.layoutUIOffset = .init(horizontal: 18, vertical: 80)
-            }
             feedbackOptions.useShakeGesture = true
             feedbackOptions.showFormForScreenshots = true
             feedbackOptions.configureForm = { formOptions in
@@ -206,6 +202,24 @@ struct FlinkyApp: App {
                 // Track feedback form closing using metrics - better for aggregate counts than individual events
                 SentryMetricsHelper.trackFeedbackFormClosed()
             }
+            feedbackOptions.onSubmitSuccess = { _ in
+                let breadcrumb = Breadcrumb(level: .info, category: "user_feedback")
+                breadcrumb.message = "User successfully submitted feedback"
+                SentrySDK.addBreadcrumb(breadcrumb)
+
+                DispatchQueue.main.async {
+                    toastManager.success(description: L10n.Feedback.Toast.Submit.success)
+                }
+            }
+            feedbackOptions.onSubmitError = { error in
+                let breadcrumb = Breadcrumb(level: .error, category: "user_feedback")
+                breadcrumb.message = "Feedback submission failed: \(error.localizedDescription)"
+                SentrySDK.addBreadcrumb(breadcrumb)
+
+                DispatchQueue.main.async {
+                    toastManager.error(description: L10n.Feedback.Toast.Submit.error)
+                }
+            }
         }
 
         // Configure Logs
@@ -225,6 +239,9 @@ struct FlinkyApp: App {
     var body: some Scene {
         WindowGroup {
             MainContainerView()
+                .environment(\.feedback, FeedbackAction {
+                    SentrySDK.feedback.show()
+                })
                 .toaster(toastManager)
                 .configureOnLaunch { options in
                     options.publicKey = "30d2f7cc2fa469eaf8e4bdf958ad9d66bce491a7da1fb08ff0a7156a8e15a47d"

--- a/Targets/App/Sources/Resources/Localizable.xcstrings
+++ b/Targets/App/Sources/Resources/Localizable.xcstrings
@@ -795,6 +795,42 @@
         }
       }
     },
+    "shared.button.feedback.accessibility.hint": {
+      "comment": "Feedback button accessibility hint",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send feedback to help improve the app"
+          }
+        }
+      }
+    },
+    "shared.button.feedback.accessibility.label": {
+      "comment": "Feedback button accessibility label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Feedback"
+          }
+        }
+      }
+    },
+    "shared.button.feedback.label": {
+      "comment": "Feedback button text",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Feedback"
+          }
+        }
+      }
+    },
     "shared.color-picker.accessibility.label": {
       "comment": "Color picker accessibility label",
       "extractionState": "manual",
@@ -1463,6 +1499,30 @@
           "stringUnit": {
             "state": "translated",
             "value": "Warning: %@"
+          }
+        }
+      }
+    },
+    "feedback.toast.submit.success": {
+      "comment": "Toast message shown when feedback is submitted successfully",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback submitted successfully"
+          }
+        }
+      }
+    },
+    "feedback.toast.submit.error": {
+      "comment": "Toast message shown when feedback submission fails",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to submit feedback"
           }
         }
       }

--- a/Targets/App/Sources/Resources/Settings.bundle/Licenses.latest_result.txt
+++ b/Targets/App/Sources/Resources/Settings.bundle/Licenses.latest_result.txt
@@ -1,12 +1,12 @@
 name: OnLaunch-iOS-Client, nameSpecified: OnLaunch-iOS-Client, owner: kula-app, version: 0.0.6, source: https://github.com/kula-app/OnLaunch-iOS-Client
 
-name: sentry-cocoa, nameSpecified: Sentry, owner: getsentry, version: 9.17.0, source: https://github.com/getsentry/sentry-cocoa
+name: sentry-cocoa, nameSpecified: Sentry, owner: getsentry, version: 9.18.0, source: https://github.com/getsentry/sentry-cocoa
 
 name: SFSafeSymbols, nameSpecified: SFSafeSymbols, owner: SFSafeSymbols, version: 7.0.0, source: https://github.com/SFSafeSymbols/SFSafeSymbols
 
 name: OnLaunch-iOS-Client, nameSpecified: OnLaunch-iOS-Client, owner: kula-app, version: 0.0.6, source: https://github.com/kula-app/OnLaunch-iOS-Client
 
-name: sentry-cocoa, nameSpecified: Sentry, owner: getsentry, version: 9.17.0, source: https://github.com/getsentry/sentry-cocoa
+name: sentry-cocoa, nameSpecified: Sentry, owner: getsentry, version: 9.18.0, source: https://github.com/getsentry/sentry-cocoa
 
 name: SFSafeSymbols, nameSpecified: SFSafeSymbols, owner: SFSafeSymbols, version: 7.0.0, source: https://github.com/SFSafeSymbols/SFSafeSymbols
 

--- a/Targets/App/Sources/Resources/Settings.bundle/Licenses.plist
+++ b/Targets/App/Sources/Resources/Settings.bundle/Licenses.plist
@@ -22,7 +22,7 @@
 			<key>File</key>
 			<string>Licenses/sentry-cocoa</string>
 			<key>Title</key>
-			<string>Sentry (9.17.0)</string>
+			<string>Sentry (9.18.0)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Targets/App/Sources/UI/CreateLinkEditor/CreateLinkEditorRenderView.swift
+++ b/Targets/App/Sources/UI/CreateLinkEditor/CreateLinkEditorRenderView.swift
@@ -1,3 +1,4 @@
+import SFSafeSymbols
 import SwiftUI
 
 struct CreateLinkEditorRenderView: View {
@@ -7,6 +8,7 @@ struct CreateLinkEditorRenderView: View {
     }
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.feedback) private var feedback
 
     @Binding var name: String
     @Binding var url: String
@@ -54,6 +56,16 @@ struct CreateLinkEditorRenderView: View {
                 .accessibilityLabel(L10n.Shared.Button.Cancel.Accessibility.label)
                 .accessibilityHint(L10n.Shared.Button.Cancel.Accessibility.hint)
                 .accessibilityIdentifier("create-link.cancel.button")
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: {
+                    feedback.show()
+                }, label: {
+                    Label(L10n.Shared.Button.Feedback.label, systemSymbol: .megaphone)
+                })
+                .accessibilityLabel(L10n.Shared.Button.Feedback.Accessibility.label)
+                .accessibilityHint(L10n.Shared.Button.Feedback.Accessibility.hint)
+                .accessibilityIdentifier("create-link.feedback.button")
             }
             ToolbarItem(placement: .confirmationAction) {
                 if #available(iOS 26, *) {

--- a/Targets/App/Sources/UI/CreateLinkWithoutListEditor/CreateLinkWithListPickerEditorRenderView.swift
+++ b/Targets/App/Sources/UI/CreateLinkWithoutListEditor/CreateLinkWithListPickerEditorRenderView.swift
@@ -7,6 +7,7 @@ struct CreateLinkWithListPickerEditorRenderView<PickerDestination: View>: View {
     }
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.feedback) private var feedback
 
     @FocusState private var focusedField: Field?
 
@@ -36,6 +37,16 @@ struct CreateLinkWithListPickerEditorRenderView<PickerDestination: View>: View {
                 }
                 .accessibilityLabel(L10n.Shared.Button.Cancel.Accessibility.label)
                 .accessibilityHint(L10n.Shared.Button.Cancel.Accessibility.hint)
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: {
+                    feedback.show()
+                }, label: {
+                    Label(L10n.Shared.Button.Feedback.label, systemSymbol: .megaphone)
+                })
+                .accessibilityLabel(L10n.Shared.Button.Feedback.Accessibility.label)
+                .accessibilityHint(L10n.Shared.Button.Feedback.Accessibility.hint)
+                .accessibilityIdentifier("create-link.feedback.button")
             }
             if #available(iOS 26, *) {
                 ToolbarItem(placement: .confirmationAction) {

--- a/Targets/App/Sources/UI/CreateListEditor/CreateLinkListEditorRenderView.swift
+++ b/Targets/App/Sources/UI/CreateListEditor/CreateLinkListEditorRenderView.swift
@@ -1,3 +1,4 @@
+import SFSafeSymbols
 import SwiftUI
 
 struct CreateLinkListEditorRenderView: View {
@@ -6,6 +7,7 @@ struct CreateLinkListEditorRenderView: View {
     }
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.feedback) private var feedback
 
     @Binding var name: String
     @FocusState private var focusedField: CreateField?
@@ -27,6 +29,16 @@ struct CreateLinkListEditorRenderView: View {
         .navigationTitle(L10n.CreateList.title)
         .accessibilityIdentifier("create-link-list.container")
         .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: {
+                    feedback.show()
+                }, label: {
+                    Label(L10n.Shared.Button.Feedback.label, systemSymbol: .megaphone)
+                })
+                .accessibilityLabel(L10n.Shared.Button.Feedback.Accessibility.label)
+                .accessibilityHint(L10n.Shared.Button.Feedback.Accessibility.hint)
+                .accessibilityIdentifier("create-link-list.feedback.button")
+            }
             ToolbarItem(placement: .cancellationAction) {
                     Button(role: .cancel) {
                         dismiss()

--- a/Targets/App/Sources/UI/LinkDetail/LinkDetailRenderView.swift
+++ b/Targets/App/Sources/UI/LinkDetail/LinkDetailRenderView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct LinkDetailRenderView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.feedback) private var feedback
 
     let linkId: UUID
 
@@ -59,6 +60,16 @@ struct LinkDetailRenderView: View {
                     menu.tint(.white)
                 }
                 .accessibilityIdentifier("link-detail.more-menu.button")
+            }
+            ToolbarItemGroup(placement: .topBarLeading) {
+                Button(action: {
+                    feedback.show()
+                }, label: {
+                    Label(L10n.Shared.Button.Feedback.label, systemSymbol: .megaphone)
+                })
+                .accessibilityLabel(L10n.Shared.Button.Feedback.Accessibility.label)
+                .accessibilityHint(L10n.Shared.Button.Feedback.Accessibility.hint)
+                .accessibilityIdentifier("link-detail.feedback.button")
             }
             if #available(iOS 26, *) {
                 ToolbarItem(placement: .confirmationAction) {

--- a/Targets/App/Sources/UI/LinkInfo/LinkInfoRenderView.swift
+++ b/Targets/App/Sources/UI/LinkInfo/LinkInfoRenderView.swift
@@ -3,6 +3,8 @@ import SFSafeSymbols
 import SwiftUI
 
 struct LinkInfoRenderView: View {
+    @Environment(\.feedback) private var feedback
+
     @Binding var name: String
     @Binding var url: String
     @Binding var color: ListColor
@@ -33,6 +35,16 @@ struct LinkInfoRenderView: View {
                 .accessibilityLabel(L10n.Shared.Button.Cancel.Accessibility.label)
                 .accessibilityHint(L10n.Shared.Button.Cancel.Accessibility.hint)
                 .accessibilityIdentifier("link-info.cancel.button")
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: {
+                    feedback.show()
+                }, label: {
+                    Label(L10n.Shared.Button.Feedback.label, systemSymbol: .megaphone)
+                })
+                .accessibilityLabel(L10n.Shared.Button.Feedback.Accessibility.label)
+                .accessibilityHint(L10n.Shared.Button.Feedback.Accessibility.hint)
+                .accessibilityIdentifier("link-info.feedback.button")
             }
             if #available(iOS 26, *) {
                 ToolbarItem(placement: .confirmationAction) {
@@ -171,8 +183,8 @@ extension LinkInfoRenderView {
                     .font(.system(size: 22, weight: .medium))
                     .foregroundStyle(
                         symbol.isEmoji
-                            ? Color.blue
-                            : (colorScheme == .light ? Color.gray.mix(with: Color.black, by: 0.3) : Color.gray)
+                        ? Color.blue
+                        : (colorScheme == .light ? Color.gray.mix(with: Color.black, by: 0.3) : Color.gray)
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(6)
@@ -180,7 +192,7 @@ extension LinkInfoRenderView {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(
                         symbol.isEmoji
-                            ? Color.blue.opacity(0.15) : Color.gray.opacity(colorScheme == .light ? 0.1 : 0.2)
+                        ? Color.blue.opacity(0.15) : Color.gray.opacity(colorScheme == .light ? 0.1 : 0.2)
                     )
                     .clipShape(Circle())
                     .contentShape(Circle())

--- a/Targets/App/Sources/UI/LinkListDetail/LinkListDetailRenderView.swift
+++ b/Targets/App/Sources/UI/LinkListDetail/LinkListDetailRenderView.swift
@@ -3,6 +3,8 @@ import SFSafeSymbols
 import SwiftUI
 
 struct LinkListDetailRenderView: View {
+    @Environment(\.feedback) private var feedback
+
     let list: LinkListsDisplayItem
     let links: [LinkListDetailDisplayItem]
 
@@ -30,10 +32,20 @@ struct LinkListDetailRenderView: View {
                 emptyStateView
             }
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: {
+                        feedback.show()
+                    }, label: {
+                        Label(L10n.Shared.Button.Feedback.label, systemSymbol: .megaphone)
+                    })
+                    .accessibilityLabel(L10n.Shared.Button.Feedback.Accessibility.label)
+                    .accessibilityHint(L10n.Shared.Button.Feedback.Accessibility.hint)
+                    .accessibilityIdentifier("link-list-detail.feedback.button")
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     sortMenu
                 }
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     moreMenu
                 }
                 if #available(iOS 26, *) {

--- a/Targets/App/Sources/UI/LinkLists/LinkListsContainerView.swift
+++ b/Targets/App/Sources/UI/LinkLists/LinkListsContainerView.swift
@@ -194,11 +194,6 @@ struct LinkListsContainerView: View {
             }
         }
         .sentryTrace("LINK_LISTS_VIEW")
-        .onAppear {
-            // Auto-injecting Sentry feedback widget is currently not supported in SwiftUI.
-            // Therefore we manually trigger it when the view appears.
-            SentrySDK.feedback.showWidget()
-        }
         .onChange(of: searchText) { oldValue, newValue in
             // Track search when user starts searching (transitions from empty to non-empty)
             if oldValue.isEmpty && !newValue.isEmpty {

--- a/Targets/App/Sources/UI/LinkLists/LinkListsRenderView.swift
+++ b/Targets/App/Sources/UI/LinkLists/LinkListsRenderView.swift
@@ -2,6 +2,8 @@ import SFSafeSymbols
 import SwiftUI
 
 struct LinkListsRenderView<Destination: View>: View {
+    @Environment(\.feedback) private var feedback
+
     let pinnedLists: [LinkListsDisplayItem]
     let unpinnedLists: [LinkListsDisplayItem]
 
@@ -71,6 +73,16 @@ struct LinkListsRenderView<Destination: View>: View {
         }
         .ifAvailable(.iOS26, modify: { view in
             view.toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: {
+                        feedback.show()
+                    }, label: {
+                        Label(L10n.Shared.Button.Feedback.label, systemSymbol: .megaphone)
+                    })
+                    .accessibilityLabel(L10n.Shared.Button.Feedback.Accessibility.label)
+                    .accessibilityHint(L10n.Shared.Button.Feedback.Accessibility.hint)
+                    .accessibilityIdentifier("link-lists.feedback.button")
+                }
                 if !pinnedLists.isEmpty || !unpinnedLists.isEmpty {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         EditButton()
@@ -111,6 +123,16 @@ struct LinkListsRenderView<Destination: View>: View {
             }
         }, elseModify: { view in
             view.toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: {
+                        feedback.show()
+                    }, label: {
+                        Label(L10n.Shared.Button.Feedback.label, systemSymbol: .megaphone)
+                    })
+                    .accessibilityLabel(L10n.Shared.Button.Feedback.Accessibility.label)
+                    .accessibilityHint(L10n.Shared.Button.Feedback.Accessibility.hint)
+                    .accessibilityIdentifier("link-lists.feedback.button")
+                }
                 if !pinnedLists.isEmpty || !unpinnedLists.isEmpty {
                     ToolbarItem(placement: .topBarTrailing) {
                         EditButton()

--- a/Targets/UITests/Sources/UITests.swift
+++ b/Targets/UITests/Sources/UITests.swift
@@ -2,15 +2,143 @@ import XCTest
 
 final class UITests: XCTestCase {
 
+    private var app: XCUIApplication!
+
     override func setUpWithError() throws {
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchEnvironment["TESTING"] = "1"
+        app.launch()
     }
 
     @MainActor
     func testLaunchPerformance() throws {
         measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+            let app = XCUIApplication()
+            app.launchEnvironment["TESTING"] = "1"
+            app.launch()
         }
+    }
+
+    // MARK: - Feedback Button Tests
+
+    func testFeedbackButtonExistsOnListsView() throws {
+        // -- Act --
+        let feedbackButton = app.buttons["link-lists.feedback.button"]
+        XCTAssertTrue(feedbackButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(feedbackButton.isHittable)
+        feedbackButton.tap()
+
+        // -- Assert --
+        assertFeedbackSubmitButtonExists()
+    }
+
+    func testFeedbackButtonExistsOnListDetailView() throws {
+        // -- Arrange --
+        navigateToListDetail()
+
+        // -- Act --
+        let feedbackButton = app.buttons["link-list-detail.feedback.button"]
+        XCTAssertTrue(feedbackButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(feedbackButton.isHittable)
+        feedbackButton.tap()
+
+        // -- Assert --
+        assertFeedbackSubmitButtonExists()
+    }
+
+    func testFeedbackButtonExistsOnLinkDetailView() throws {
+        // -- Arrange --
+        navigateToLinkDetail()
+
+        // -- Act --
+        let feedbackButton = app.buttons["link-detail.feedback.button"]
+        XCTAssertTrue(feedbackButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(feedbackButton.isHittable)
+        feedbackButton.tap()
+
+        // -- Assert --
+        assertFeedbackSubmitButtonExists()
+    }
+
+    func testFeedbackButtonExistsOnLinkInfoView() throws {
+        // -- Arrange --
+        navigateToLinkDetail()
+
+        let moreMenu = app.buttons["link-detail.more-menu.button"]
+        XCTAssertTrue(moreMenu.waitForExistence(timeout: 5))
+        moreMenu.tap()
+
+        let editButton = app.buttons["Edit"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 5))
+        editButton.tap()
+
+        // -- Act --
+        let feedbackButton = app.buttons["link-info.feedback.button"]
+        XCTAssertTrue(feedbackButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(feedbackButton.isHittable)
+        feedbackButton.tap()
+
+        // -- Assert --
+        assertFeedbackSubmitButtonExists()
+    }
+
+    func testFeedbackButtonExistsOnCreateListView() throws {
+        // -- Arrange --
+        let createListButton = app.buttons["link-lists.create-list.button"]
+        XCTAssertTrue(createListButton.waitForExistence(timeout: 5))
+        createListButton.tap()
+
+        // -- Act --
+        let feedbackButton = app.buttons["create-link-list.feedback.button"]
+        XCTAssertTrue(feedbackButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(feedbackButton.isHittable)
+        feedbackButton.tap()
+
+        // -- Assert --
+        assertFeedbackSubmitButtonExists()
+    }
+
+    func testFeedbackButtonExistsOnCreateLinkView() throws {
+        // -- Arrange --
+        navigateToListDetail()
+
+        let newLinkButton = app.buttons["link-list-detail.new-link.button"]
+        XCTAssertTrue(newLinkButton.waitForExistence(timeout: 5))
+        newLinkButton.tap()
+
+        // -- Act --
+        let feedbackButton = app.buttons["create-link.feedback.button"]
+        XCTAssertTrue(feedbackButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(feedbackButton.isHittable)
+        feedbackButton.tap()
+
+        // -- Assert --
+        assertFeedbackSubmitButtonExists()
+    }
+
+    // MARK: - Navigation Helpers
+
+    private func navigateToListDetail() {
+        let myLinksRow = app.cells.containing(.staticText, identifier: "My Links").firstMatch
+        XCTAssertTrue(myLinksRow.waitForExistence(timeout: 5))
+        myLinksRow.tap()
+
+        XCTAssertTrue(app.navigationBars["My Links"].waitForExistence(timeout: 5))
+    }
+
+    private func navigateToLinkDetail() {
+        navigateToListDetail()
+
+        let appleRow = app.cells.containing(.staticText, identifier: "Apple").firstMatch
+        XCTAssertTrue(appleRow.waitForExistence(timeout: 5))
+        appleRow.tap()
+    }
+
+    // MARK: - Assertion Helpers
+
+    private func assertFeedbackSubmitButtonExists() {
+        let submitButton = app.buttons["io.sentry.feedback.form.submit"].firstMatch
+        XCTAssertTrue(submitButton.waitForExistence(timeout: 5))
     }
 }


### PR DESCRIPTION
## Summary

- Add a feedback megaphone toolbar button to all 6 main screens (lists, list detail, link detail, link info, create list, create link)
- Introduce `FeedbackAction` environment value so views call `feedback.show()` without importing SentrySwift directly
- Adopt the new `SentryFeedbackFormConfig` API from sentry-cocoa for manual feedback form presentation
- Remove the floating feedback widget (`showWidget()`) in favor of explicit toolbar buttons
- Remove dead widget configuration from `configureUserFeedback`
- Add localization strings for the feedback button (label, accessibility label/hint)

## Test plan

- [x] UI tests for all 6 feedback buttons pass (`make test-ui-ios-app`, 7/7 green)
- [x] Each test navigates to the screen, taps the feedback button, and verifies the Sentry feedback form opens
- [x] Tests run with `TESTING=1` (Sentry disabled, in-memory DB) so no real feedback is sent
- [x] `make build` succeeds