### PR TITLE
fix(share-extension): Add typed error enum

### DIFF
--- a/Targets/ShareExtension/Sources/Generated/L10n.swift
+++ b/Targets/ShareExtension/Sources/Generated/L10n.swift
@@ -17,12 +17,18 @@ internal enum L10n {
             internal static let name = L10n.tr("share-extension.default-list.name", fallback: "My Links")
         }
         internal enum Error {
-            /// Invalid URL shared
-            internal static let invalidUrl = L10n.tr("share-extension.error.invalid-url", fallback: "Invalid URL shared")
-            /// No URL found in shared content
-            internal static let noUrl = L10n.tr("share-extension.error.no-url", fallback: "No URL found in shared content")
-            /// Failed to save link
-            internal static let saveFailed = L10n.tr("share-extension.error.save-failed", fallback: "Failed to save link")
+            internal enum InvalidUrl {
+                /// Item is not an URL
+                internal static let description = L10n.tr("share-extension.error.invalid-url.description", fallback: "Item is not an URL")
+                /// This should not happen. The developer will be informed.
+                internal static let recoverySuggestion = L10n.tr("share-extension.error.invalid-url.recovery-suggestion", fallback: "This should not happen. The developer will be informed.")
+            }
+            internal enum NoUrl {
+                /// No URL found in shared content
+                internal static let description = L10n.tr("share-extension.error.no-url.description", fallback: "No URL found in shared content")
+                /// Try sharing the URL again.
+                internal static let recoverySuggestion = L10n.tr("share-extension.error.no-url.recovery-suggestion", fallback: "Try sharing the URL again.")
+            }
         }
         internal enum ListPicker {
             /// List

--- a/Targets/ShareExtension/Sources/Resources/Localizable.xcstrings
+++ b/Targets/ShareExtension/Sources/Resources/Localizable.xcstrings
@@ -13,19 +13,31 @@
         }
       }
     },
-    "share-extension.error.invalid-url" : {
+    "share-extension.error.invalid-url.description" : {
       "comment" : "Error when shared URL is invalid",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invalid URL shared"
+            "value" : "Item is not an URL"
           }
         }
       }
     },
-    "share-extension.error.no-url" : {
+    "share-extension.error.invalid-url.recovery-suggestion" : {
+      "comment" : "Recovery suggestion indicating that this is a valid error path which should not happen",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This should not happen. The developer will be informed."
+          }
+        }
+      }
+    },
+    "share-extension.error.no-url.description" : {
       "comment" : "Error when no URL is found in shared content",
       "extractionState" : "manual",
       "localizations" : {
@@ -37,14 +49,14 @@
         }
       }
     },
-    "share-extension.error.save-failed" : {
-      "comment" : "Error when saving link fails",
+    "share-extension.error.no-url.recovery-suggestion" : {
+      "comment" : "Recovery suggestion when no URL was found in the sharing payload",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Failed to save link"
+            "value" : "Try sharing the URL again."
           }
         }
       }

--- a/Targets/ShareExtension/Sources/ShareViewController.swift
+++ b/Targets/ShareExtension/Sources/ShareViewController.swift
@@ -348,7 +348,7 @@ class ShareViewController: SLComposeServiceViewController { // swiftlint:disable
         //
         // Using Sentry we can capture these cases to ensure they are not happening in production.
         Self.logger.error("No valid URL found in shared items, cancelling extension request")
-        SentrySDK.capture(error: ShareExtensionError.noValidURL) { scope in
+        SentrySDK.capture(error: ShareExtensionError.noValidURLFound) { scope in
             scope.setTag(value: "share_extension", key: "operation")
             scope.setContext(
                 value: [
@@ -369,7 +369,7 @@ class ShareViewController: SLComposeServiceViewController { // swiftlint:disable
         do {
             let item = try await attachment.loadItem(forTypeIdentifier: UTType.url.identifier)
             guard let itemUrl = item as? URL else {
-                throw NSError(domain: "ShareExtensionError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Item is not a valid URL"])
+                throw ShareExtensionError.notAnURLExtensionItem
             }
             url = itemUrl
         } catch {

--- a/Targets/ShareExtension/Sources/Utils/ShareExtensionError.swift
+++ b/Targets/ShareExtension/Sources/Utils/ShareExtensionError.swift
@@ -1,12 +1,33 @@
 import Foundation
 
-enum ShareExtensionError: LocalizedError {
-    case noValidURL
+enum ShareExtensionError: LocalizedError, CustomStringConvertible {
+    case noValidURLFound
+    case notAnURLExtensionItem
 
     var errorDescription: String? {
         switch self {
-        case .noValidURL:
+        case .noValidURLFound:
+            return L10n.ShareExtension.Error.NoUrl.description
+        case .notAnURLExtensionItem:
+            return L10n.ShareExtension.Error.InvalidUrl.description
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .noValidURLFound:
+            return L10n.ShareExtension.Error.NoUrl.recoverySuggestion
+        case .notAnURLExtensionItem:
+            return L10n.ShareExtension.Error.InvalidUrl.recoverySuggestion
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .noValidURLFound:
             return "No valid URL found in shared items"
+        case .notAnURLExtensionItem:
+            return "Item is not a URL"
         }
     }
 }


### PR DESCRIPTION
Building an NSError object was a quick & dirty solution, so this PR introduces a proper Swift error type.

Closes #76