### PR TITLE
ci(fastlane): Switch build_ci to development signing for Sentry App Analysis

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -6,15 +6,15 @@
 # Lanes for building the app in CI and local environments.
 # ============================================================================
 
-desc "Build the app for CI (creates archive for App Store distribution)"
+desc "Build the app for CI (creates development archive and uploads to Sentry App Analysis)"
 lane :build_ci do
   # Configure CI keychain and set match to readonly to avoid prompts
   setup_ci if is_ci
 
-  # Setup code signing
-  _setup_code_signing
+  # Setup development code signing
+  _setup_code_signing_development
 
-  # Build and export the app to an archive
+  # Build and export the app as a development build
   build_app(
     project: "Flinky.xcodeproj",
     scheme: "App",
@@ -22,12 +22,12 @@ lane :build_ci do
     build_path: ".",
     export_options: {
       "destination" => "export",
-      "method" => "app-store-connect",
+      "method" => "development",
       "provisioningProfiles" => {
-        "com.techprimate.Flinky" => "match AppStore com.techprimate.Flinky",
-        "com.techprimate.Flinky.ShareExtension" => "match AppStore com.techprimate.Flinky.ShareExtension"
+        "com.techprimate.Flinky" => "match Development com.techprimate.Flinky",
+        "com.techprimate.Flinky.ShareExtension" => "match Development com.techprimate.Flinky.ShareExtension"
       },
-      "signingCertificate" => "Apple Distribution",
+      "signingCertificate" => "Apple Development",
       "signingStyle" => "manual",
       "teamID" => "BZ362SQ6AB"
     }

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -18,6 +18,7 @@ lane :build_ci do
   build_app(
     project: "Flinky.xcodeproj",
     scheme: "App",
+    configuration: "Debug",
     archive_path: "./Flinky.xcarchive",
     build_path: ".",
     export_options: {

--- a/fastlane/lanes/helpers.rb
+++ b/fastlane/lanes/helpers.rb
@@ -72,6 +72,22 @@ private_lane :_setup_code_signing do
   )
 end
 
+# Private lane: Setup code signing for Development builds
+private_lane :_setup_code_signing_development do
+  sync_code_signing(
+    type: "development",
+    readonly: true,
+    app_identifier: "com.techprimate.Flinky",
+    git_private_key: ENV["MATCH_GIT_PRIVATE_KEY"]
+  )
+  sync_code_signing(
+    type: "development",
+    readonly: true,
+    app_identifier: "com.techprimate.Flinky.ShareExtension",
+    git_private_key: ENV["MATCH_GIT_PRIVATE_KEY"]
+  )
+end
+
 # Private lane: Increment version and build number, return both values
 private_lane :_increment_version_and_build do
   version_number = get_version_number(


### PR DESCRIPTION
Switch the `build_ci` lane from App Store signing to development signing.
App Store certificates and provisioning profiles are only needed for
TestFlight/App Store uploads (handled by the release lanes). The CI build
job only needs to verify the build succeeds and upload the archive to
Sentry App Analysis, which works with development-signed builds.

Changes:
- Add `_setup_code_signing_development` private lane in `helpers.rb`
- Update `build_ci` to use development signing (`Apple Development`
  certificate, `match Development` profiles, `development` export method)
- Release lanes (`release_ci`, `release_beta_ci`, `beta`, `publish`)
  remain unchanged — they still use App Store signing