### PR TITLE
fix(ui): Skip EDR Metal path on iOS Simulator

### DIFF
--- a/Targets/App/Sources/UI/Components/EDRMetalView.swift
+++ b/Targets/App/Sources/UI/Components/EDRMetalView.swift
@@ -7,10 +7,19 @@ struct EDRMetalView: UIViewRepresentable {
     /// Whether the current device supports EDR rendering via Metal.
     ///
     /// Callers should check this before entering the EDR rendering path to avoid
-    /// displaying a blank view on unsupported devices (e.g. the iOS Simulator).
-    /// This property reads from `Renderer.device`, the same shared `MTLDevice`
-    /// that the renderer uses, so the check is consistent with actual rendering capability.
-    static var isSupported: Bool { Renderer.device != nil }
+    /// displaying a blank view on unsupported devices. Always returns `false` on
+    /// the iOS Simulator: on Apple Silicon hosts `MTLCreateSystemDefaultDevice()`
+    /// returns a device, but Metal-backed views don't render correctly for
+    /// `XCUIScreenshot` capture, and the resulting `MTKView` doesn't expose as an
+    /// accessibility image element. Both matter for the App Store screenshot
+    /// pipeline, which renders on simulators.
+    static var isSupported: Bool {
+        #if targetEnvironment(simulator)
+        return false
+        #else
+        return Renderer.device != nil
+        #endif
+    }
 
     let imageProvider: (_ contentScaleFactor: CGFloat, _ headroom: CGFloat) -> CIImage?
 


### PR DESCRIPTION
`EDRMetalView.isSupported` checked `MTLCreateSystemDefaultDevice() != nil`, which returns true on Apple Silicon iOS Simulator hosts. As a result, `LinkDetailRenderView` rendered the QR code through an `MTKView` on the simulator, which broke two things:

1. **Screenshot UI test** at `ScreenshotUITests.swift:97` — `app.images["link-detail.qr-code.container"]` can't find the container because the wrapping `VStack` no longer exposes as an accessibility image element when its child is an `MTKView`.
2. **App Store screenshots** — `MTKView` doesn't render reliably into `XCUIScreenshot` PNGs, so the QR screen screenshot would be blank/incorrect even if the assertion weren't looking for `.images`.

Introduced by #116 (EDR bright display for QR codes).

`isSupported` now returns `false` under `#if targetEnvironment(simulator)`, falling back to the SwiftUI `Image(uiImage:)` path. Real devices still get EDR Metal rendering.

This has been silently broken on main since #116 landed: the PR-level `Screenshots` job runs `generate_screenshots_ci` → `fastlane capture_screenshots`, which reports test failures in its own results table (❌) but still exits 0 and prints `✅ generated successfully`. The failure surfaced now because the new parallel screenshot pipeline on #113 uses `run_tests` with `fail_build: true`. `generate_screenshots_ci` should be hardened to propagate test failures — tracking separately.

Unblocks #113.