### PR TITLE
ci: Set simulator boot wait for snapshot status bar override

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -153,6 +153,12 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           LICENSE_PLIST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Simulator boot is slow on hosted runners. Without this, snapshot
+          # runs `simctl status_bar override` with a 0s wait (see bug in
+          # fastlane's simulator_launcher_base.rb:129 — `nil.to_i || 10` is 0,
+          # not 10) and the override silently no-ops against a not-yet-booted
+          # simulator, so the real clock time leaks into the screenshots.
+          SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT: "30"
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -66,6 +66,8 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           LICENSE_PLIST_GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
+          # See build-test.yml for why this is needed on hosted runners.
+          SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT: "30"
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
           LICENSE_PLIST_GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
           RELEASE_BOT_TOKEN: ${{ steps.github_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          # See build-test.yml for why this is needed on hosted runners.
+          SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT: "30"
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
CI screenshots were shipping with the real wall-clock time (e.g. 8:41, 8:43) instead of the expected 9:41. Snapshot prints on every run:

```
Waiting 0 seconds for device to fully boot before overriding status bar...
Set 'SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT' environment variable to adjust timeout
```

With a 0s wait, `xcrun simctl status_bar override` runs against a not-yet-booted simulator, silently no-ops, and the real clock leaks into the screenshots.

Root cause is a bug in fastlane/snapshot itself (still unfixed in 2.233.0), in `simulator_launcher_base.rb:129`:

```ruby
boot_sleep = ENV["SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT"].to_i || 10
```

In Ruby `nil.to_i == 0`, and `0 || 10` evaluates to `0` because `0` is truthy. The documented 10-second default is actually 0 unless the env var is set.

Fix: set `SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT=30` on the CI job steps that invoke snapshot lanes (`build-test.yml` Screenshots job, `release.yml` Release step). Scoped to CI because hosted runners are slow; local Macs boot the simulator fast enough that the 0s wait rarely bites.

Worth reporting the Ruby truthiness bug upstream — one-liner fix like `(ENV[...] || "10").to_i` — but for now this is the right workaround.