### PR TITLE
fix(ci): wait for iOS simulator before running screenshot tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,15 @@ jobs:
           name: screenshot-test-bundle
           path: /tmp/screenshot_build/Build/Products/
 
+      - name: Wait for iOS Simulator
+        uses: kula-app/wait-for-services-action/ios-simulator@v1
+        with:
+          device: ${{ matrix.device }}
+          boot: true
+          warm-xcodebuild-settings: true
+          project: Flinky.xcodeproj
+          scheme: ScreenshotUITests
+
       - name: Run Screenshots
         run: bundle exec fastlane run_screenshot_on_device "device:${{ matrix.device }}" derived_data_path:/tmp/screenshot_build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           path: /tmp/screenshot_build/Build/Products/
 
       - name: Wait for iOS Simulator
-        uses: kula-app/wait-for-services-action/ios-simulator@v1
+        uses: kula-app/wait-for-services-action/ios-simulator@main
         with:
           device: ${{ matrix.device }}
           boot: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,7 @@ jobs:
           path: /tmp/screenshot_build/Build/Products/
 
       - name: Wait for iOS Simulator
+        id: simulator
         uses: kula-app/wait-for-services-action/ios-simulator@main
         with:
           device: ${{ matrix.device }}
@@ -196,7 +197,7 @@ jobs:
           scheme: ScreenshotUITests
 
       - name: Run Screenshots
-        run: bundle exec fastlane run_screenshot_on_device "device:${{ matrix.device }}" derived_data_path:/tmp/screenshot_build
+        run: bundle exec fastlane run_screenshot_on_device "device:${{ matrix.device }}" "simulator_udid:${{ steps.simulator.outputs.udid }}" derived_data_path:/tmp/screenshot_build
 
       - name: Upload Device Screenshots
         uses: actions/upload-artifact@v7

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -100,7 +100,8 @@ lane :run_screenshot_on_device do |options|
   UI.message "Running screenshots on: #{device}"
 
   # Boot simulator and override status bar
-  simulator_udid = options[:simulator_udid]
+  simulator_udid = options[:simulator_udid]&.strip
+  simulator_udid = nil if simulator_udid&.empty?
   if simulator_udid
     UI.message "Using pre-resolved simulator UDID: #{simulator_udid}"
   else

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -127,7 +127,7 @@ lane :run_screenshot_on_device do |options|
         output_remove_retry_attempts: true,
         fail_build: false
       )
-      last_failures = result[:number_of_failures_excluding_retries] || 0
+      last_failures = result&.dig(:number_of_failures_excluding_retries) || 0
     ensure
       _clear_status_bar(udid: simulator_udid)
     end

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -127,7 +127,12 @@ lane :run_screenshot_on_device do |options|
         output_remove_retry_attempts: true,
         fail_build: false
       )
-      last_failures = result&.dig(:number_of_failures_excluding_retries) || 0
+      if result.nil?
+        UI.error "run_tests returned no result — treating as failure"
+        last_failures = 1
+      else
+        last_failures = result[:number_of_failures_excluding_retries] || 0
+      end
     ensure
       _clear_status_bar(udid: simulator_udid)
     end

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -72,6 +72,7 @@ desc <<~DESC
   Handles simulator status bar override and screenshot collection.
   Options:
     device: simulator device name (required, e.g. "iPhone 17 Pro")
+    simulator_udid: pre-resolved simulator UDID (skips lookup and boot if provided)
     derived_data_path: path to pre-built test products (default: /tmp/screenshot_derived_data)
     language: language code for screenshots (default: en-US)
 DESC
@@ -99,9 +100,24 @@ lane :run_screenshot_on_device do |options|
   UI.message "Running screenshots on: #{device}"
 
   # Boot simulator and override status bar
-  simulator_udid = _find_simulator_udid(device: device)
-  _boot_simulator(udid: simulator_udid)
+  simulator_udid = options[:simulator_udid]
+  if simulator_udid
+    UI.message "Using pre-resolved simulator UDID: #{simulator_udid}"
+  else
+    simulator_udid = _find_simulator_udid(device: device)
+    _boot_simulator(udid: simulator_udid)
+  end
   _override_status_bar(udid: simulator_udid)
+
+  # Uninstall app before testing to ensure clean state. We handle this ourselves
+  # rather than using run_tests' reinstall_app option because scan resolves
+  # Scan.devices independently and may target a different simulator UDID when
+  # multiple runtimes are installed.
+  app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
+  if app_identifier
+    UI.message "Uninstalling #{app_identifier} from #{simulator_udid}..."
+    sh("xcrun simctl uninstall #{simulator_udid} #{app_identifier} 2>/dev/null || true")
+  end
 
   # Two layers of retry:
   #   - number_of_retries: xcodebuild reruns failing tests (-test-iterations + -retry-tests-on-failure).
@@ -119,9 +135,8 @@ lane :run_screenshot_on_device do |options|
         scheme: "ScreenshotUITests",
         xctestrun: xctestrun_path,
         test_without_building: true,
-        destination: "platform=iOS Simulator,name=#{device}",
+        destination: "platform=iOS Simulator,id=#{simulator_udid}",
         only_testing: ["ScreenshotUITests/ScreenshotUITests/testScreenshots"],
-        reinstall_app: true,
         output_types: "",
         number_of_retries: 3,
         output_remove_retry_attempts: true,


### PR DESCRIPTION
## Summary

- Adds `kula-app/wait-for-services-action/ios-simulator@v1` step before screenshot tests to pre-boot the simulator and warm the `xcodebuild -showBuildSettings` cache, preventing flaky timeouts on hosted runners
- Fixes nil-safety bug in `screenshots.rb` where `run_tests` returning `nil` (due to build settings timeout with `fail_build: false`) caused a `NoMethodError` crash

## Context

3 of 4 screenshot jobs in [run #26826536926](https://github.com/techprimate/Flinky/actions/runs/26826536926) failed because `xcodebuild -showBuildSettings` timed out on all 4 retry attempts (3s, 6s, 12s, 24s) before the tests even started. The simulator was booted by the fastlane lane, but the Xcode build system wasn't warmed up yet on the freshly provisioned macOS runner.

## Test plan

- [ ] Re-run the release workflow and verify all 4 screenshot jobs pass
- [ ] Confirm the wait step boots the simulator and warms build settings before fastlane starts