### PR TITLE
ci: Wait for iOS simulator before tests and screenshots

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,6 +63,15 @@ jobs:
       - name: Install Dependencies
         run: brew bundle --file Brewfile-ci
 
+      - name: Wait for iOS Simulator
+        uses: kula-app/wait-for-services-action/ios-simulator@main
+        with:
+          device: iPhone 17 Pro
+          boot: true
+          warm-xcodebuild-settings: true
+          project: Flinky.xcodeproj
+          scheme: App
+
       - name: Test
         run: make test-ios "DEVICE_NAME=iPhone 17 Pro"
         env:
@@ -102,6 +111,15 @@ jobs:
 
       - name: Install Dependencies
         run: brew bundle --file Brewfile-ci
+
+      - name: Wait for iOS Simulator
+        uses: kula-app/wait-for-services-action/ios-simulator@main
+        with:
+          device: iPhone 17 Pro
+          boot: true
+          warm-xcodebuild-settings: true
+          project: Flinky.xcodeproj
+          scheme: UITests
 
       - name: Test UI
         run: make test-ui-ios "DEVICE_NAME=iPhone 17 Pro"

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -61,13 +61,20 @@ jobs:
           RELEASE_BOT_TOKEN: ${{ steps.github_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
 
+      - name: Wait for iOS Simulator
+        uses: kula-app/wait-for-services-action/ios-simulator@main
+        with:
+          device: iPhone 17 Pro
+          boot: true
+          warm-xcodebuild-settings: true
+          project: Flinky.xcodeproj
+          scheme: ScreenshotUITests
+
       - name: Generate and Upload Screenshots to Sentry
         run: bundle exec fastlane generate_and_upload_screenshots_ci
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           LICENSE_PLIST_GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
-          # See build-test.yml for why this is needed on hosted runners.
-          SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT: "30"
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v7

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -31,17 +31,20 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Wait for iOS Simulator
+        uses: kula-app/wait-for-services-action/ios-simulator@main
+        with:
+          device: iPhone 17 Pro
+          boot: true
+          warm-xcodebuild-settings: true
+          project: Flinky.xcodeproj
+          scheme: ScreenshotUITests
+
       - name: Capture and Upload Screenshots
         run: bundle exec fastlane generate_and_upload_screenshots_ci
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           LICENSE_PLIST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Simulator boot is slow on hosted runners. Without this, snapshot
-          # runs `simctl status_bar override` with a 0s wait (see bug in
-          # fastlane's simulator_launcher_base.rb:129 — `nil.to_i || 10` is 0,
-          # not 10) and the override silently no-ops against a not-yet-booted
-          # simulator, so the real clock time leaks into the screenshots.
-          SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT: "30"
 
       - name: Upload Screenshots
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Add the `wait-for-services-action/ios-simulator` step to workflows that
run on a simulator but were missing proper boot handling:

- **build-test.yml**: `test` job (scheme `App`) and `test-ui` job (scheme `UITests`)
- **screenshots.yml**: screenshot capture (scheme `ScreenshotUITests`)
- **release-beta.yml**: screenshot generation (scheme `ScreenshotUITests`)

This matches the approach already used in the release workflow's parallel
screenshot jobs. The `SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT` env var
workaround is removed from screenshots and beta-release since the
simulator is now properly booted and warmed before fastlane runs.