### PR TITLE
chore(deps): update wait-for-services-action to v1.3.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -64,7 +64,7 @@ jobs:
         run: brew bundle --file Brewfile-ci
 
       - name: Wait for iOS Simulator
-        uses: kula-app/wait-for-services-action/ios-simulator@main
+        uses: kula-app/wait-for-services-action/ios-simulator@v1.3.0
         with:
           device: iPhone 17 Pro
           boot: true
@@ -113,7 +113,7 @@ jobs:
         run: brew bundle --file Brewfile-ci
 
       - name: Wait for iOS Simulator
-        uses: kula-app/wait-for-services-action/ios-simulator@main
+        uses: kula-app/wait-for-services-action/ios-simulator@v1.3.0
         with:
           device: iPhone 17 Pro
           boot: true

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Wait for iOS Simulator
-        uses: kula-app/wait-for-services-action/ios-simulator@main
+        uses: kula-app/wait-for-services-action/ios-simulator@v1.3.0
         with:
           device: iPhone 17 Pro
           boot: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Wait for iOS Simulator
         id: simulator
-        uses: kula-app/wait-for-services-action/ios-simulator@main
+        uses: kula-app/wait-for-services-action/ios-simulator@v1.3.0
         with:
           device: ${{ matrix.device }}
           boot: true

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -32,7 +32,7 @@ jobs:
           bundler-cache: true
 
       - name: Wait for iOS Simulator
-        uses: kula-app/wait-for-services-action/ios-simulator@main
+        uses: kula-app/wait-for-services-action/ios-simulator@v1.3.0
         with:
           device: iPhone 17 Pro
           boot: true


### PR DESCRIPTION
## Summary

- Pin `kula-app/wait-for-services-action/ios-simulator` from `@main` to `@v1.3.0` across all CI workflows (`build-test.yml`, `screenshots.yml`, `release.yml`, `release-beta.yml`)

## Test plan

- [ ] Verify CI workflows pass with the pinned version