### PR TITLE
ci: Add workflow to publish App Store metadata via ship CLI

### DIFF
--- a/.github/workflows/publish-metadata.yml
+++ b/.github/workflows/publish-metadata.yml
@@ -1,0 +1,31 @@
+name: Publish Metadata
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 5 * * *" # Every day at 05:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-metadata:
+    name: Publish Metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: ghcr.io/kula-app/ship:0.0.3
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Publish Metadata
+        env:
+          SHIP_APP_ID: ${{ vars.SHIP_APP_ID }}
+        run: ship publish metadata --app-id "$SHIP_APP_ID"

--- a/.github/workflows/publish-metadata.yml
+++ b/.github/workflows/publish-metadata.yml
@@ -20,11 +20,6 @@ jobs:
     container:
       image: ghcr.io/kula-app/ship:0.0.3
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-        with:
-          submodules: true
-
       - name: Publish Metadata
         env:
           SHIP_APP_ID: ${{ vars.SHIP_APP_ID }}


### PR DESCRIPTION
Adds a `Publish Metadata` GitHub Actions workflow that runs the kula-app `ship` CLI to publish App Store metadata.

It triggers on every push to `main`, nightly at 05:00 UTC, and on manual `workflow_dispatch`. The job runs inside the pre-built `ghcr.io/kula-app/ship:0.0.3` container and executes `ship publish metadata --app-id "$SHIP_APP_ID"`.

The app ID is passed through a step-level `env` variable (`SHIP_APP_ID` from repo variables) and referenced as a quoted shell variable rather than interpolated directly into the command, to avoid shell command injection.

Note: requires the `SHIP_APP_ID` repository variable to be defined. The container image is pinned to `0.0.3`.